### PR TITLE
Fix for cached Yahoo filenames to use end date

### DIFF
--- a/backtester/dataSource/yahoo_data_source.py
+++ b/backtester/dataSource/yahoo_data_source.py
@@ -109,7 +109,7 @@ class InstrumentsFromFile():
 class YahooStockDataSource(DataSource):
     def __init__(self, cachedFolderName, dataSetId, instrumentIds, startDateStr, endDateStr, event='history', adjustPrice=False, downloadId=".NS", liveUpdates=True, pad=True):
         super(YahooStockDataSource, self).__init__(cachedFolderName, dataSetId, instrumentIds, startDateStr, endDateStr)
-        self.__dateAppend = "_%sto%s"%(datetime.strptime(startDateStr, '%Y/%m/%d').strftime('%Y-%m-%d'),datetime.strptime(startDateStr, '%Y/%m/%d').strftime('%Y-%m-%d'))
+        self.__dateAppend = "_%sto%s"%(datetime.strptime(startDateStr, '%Y/%m/%d').strftime('%Y-%m-%d'),datetime.strptime(endDateStr, '%Y/%m/%d').strftime('%Y-%m-%d'))
         self.__downloadId = downloadId
         self.__bookDataByFeature = {}
         self.__adjustPrice = adjustPrice


### PR DESCRIPTION
Cached filenames for Yahoo data files use the start date as the end date. This fixes it so that the end date is used instead.