### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,5 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['requests', 'plotly', 'numpy', 'pandas', 'bs4', 'scipy', 'sklearn', 'lxml', 'tensorboard', 'tensorboardX']
+    install_requires=['requests', 'plotly', 'numpy', 'pandas', 'bs4', 'scipy', 'scikit-learn', 'lxml', 'tensorboard', 'tensorboardX']
 )


### PR DESCRIPTION
Hi, I noticed that when using the installation of auquan-toolbox in Google AI there is an error because `pip install sklearn` has been deprecated and it has been suggested to use `pip install scikit-learn` instead.  I have change sklearn to scikit-learn to prevent deprecation in the pip requirements files